### PR TITLE
Add option to provider to ignore SSL certificate errors

### DIFF
--- a/example.tf
+++ b/example.tf
@@ -28,6 +28,10 @@ provider "tss" {
   username   = var.tss_username
   password   = var.tss_password
   server_url = var.tss_server_url
+
+  # (Optional) Disables TLS certificate validation (defaults to false). 
+  # insecure  = true
+
 }
 
 data "tss_secret" "my_username" {

--- a/provider.go
+++ b/provider.go
@@ -12,6 +12,7 @@ func providerConfig(d *schema.ResourceData) (interface{}, error) {
 			Username: d.Get("username").(string),
 			Password: d.Get("password").(string),
 		},
+		InsecureTLS: d.Get("insecure").(bool),
 	}, nil
 }
 
@@ -36,6 +37,12 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The password of the Secret Server User",
+			},
+			"insecure": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Disable validation of TLS certificates",
 			},
 		},
 		ConfigureFunc: providerConfig,


### PR DESCRIPTION
Fix for issue #13. This adds an `insecure` option to the provider to prevent `x509: certificate signed by unknown authority` errors when using self signed certificates.

Pull Request thycotic/tss-sdk-go#8 is a required dependency for this request.

