### PR TITLE
Updated goreleaser to be compatible with the Terraform registry

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # if you are using this is a GitHub action or some other automated pipeline, you
+      # if you are using this in a GitHub action or some other automated pipeline, you 
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
@@ -47,10 +47,8 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
-source:
-  enabled: true
 release:
   # If you want to manually examine the release before its live, uncomment this line:
-  draft: false
+  # draft: true
 changelog:
   skip: true


### PR DESCRIPTION
This change should now allow the Terraform registry to automatically pull in this provider for public consumption. 
