### PR TITLE
Fetch Secret by Name or ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 
 # IDE
 .vscode
+.idea
 
 # terraform
 .terraform/

--- a/datasource_secret.go
+++ b/datasource_secret.go
@@ -61,16 +61,16 @@ func dataSourceSecret() *schema.Resource {
 			},
 			"id": {
 				Description: "the numerical id of the secret. Either path or id must be set, and if both are set, " +
-					"id wins.",
-				Optional: true,
-				Type:     schema.TypeInt,
+					         "id wins.",
+				Optional:    true,
+				Type:        schema.TypeInt,
 			},
 			"path": {
 				Description: "the fully-qualified path to the secret including its folder path and secret name, " +
 					"eg: '/my/folder/structure/secretName'. Either path or id must be set, and if both are " +
 					"set, id wins.",
-				Optional: true,
-				Type:     schema.TypeString,
+				Optional:    true,
+				Type:        schema.TypeString,
 			},
 		},
 	}

--- a/datasource_secret.go
+++ b/datasource_secret.go
@@ -67,8 +67,8 @@ func dataSourceSecret() *schema.Resource {
 			},
 			"path": {
 				Description: "the fully-qualified path to the secret including its folder path and secret name, " +
-					"eg: '/my/folder/structure/secretName'. Either path or id must be set, and if both are set, " +
-					"id wins.",
+					"eg: '/my/folder/structure/secretName'. Either path or id must be set, and if both are " +
+					"set, id wins.",
 				Optional: true,
 				Type:     schema.TypeString,
 			},

--- a/datasource_secret.go
+++ b/datasource_secret.go
@@ -24,7 +24,7 @@ func dataSourceSecretRead(d *schema.ResourceData, meta interface{}) error {
 	if id != 0 {
 		secret, err = secrets.Secret(id)
 	} else {
-		secret, err = secrets.SecretByPath(path)
+		secret, err = secrets.Secret(path)
 	}
 
 	if err != nil {
@@ -62,15 +62,15 @@ func dataSourceSecret() *schema.Resource {
 			"id": {
 				Description: "the numerical id of the secret. Either path or id must be set, and if both are set, " +
 					"id wins.",
-				Optional:    true,
-				Type:        schema.TypeInt,
+				Optional: true,
+				Type:     schema.TypeInt,
 			},
 			"path": {
 				Description: "the fully-qualified path to the secret including its folder path and secret name, " +
 					"eg: '/my/folder/structure/secretName'. Either path or id must be set, and if both are set, " +
 					"id wins.",
-				Optional:    true,
-				Type:        schema.TypeString,
+				Optional: true,
+				Type:     schema.TypeString,
 			},
 		},
 	}

--- a/datasource_secret.go
+++ b/datasource_secret.go
@@ -11,6 +11,7 @@ import (
 
 func dataSourceSecretRead(d *schema.ResourceData, meta interface{}) error {
 	id := d.Get("id").(int)
+	path := d.Get("path").(string)
 	field := d.Get("field").(string)
 	secrets, err := server.New(meta.(server.Configuration))
 
@@ -19,7 +20,12 @@ func dataSourceSecretRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] getting secret with id %d", id)
 
-	secret, err := secrets.Secret(id)
+	var secret *server.Secret
+	if id != 0 {
+		secret, err = secrets.Secret(id)
+	} else {
+		secret, err = secrets.SecretByPath(path)
+	}
 
 	if err != nil {
 		log.Print("[DEBUG] unable to get secret", err)
@@ -54,9 +60,17 @@ func dataSourceSecret() *schema.Resource {
 				Type:        schema.TypeString,
 			},
 			"id": {
-				Description: "the id of the secret",
-				Required:    true,
+				Description: "the numerical id of the secret. Either path or id must be set, and if both are set, " +
+					"id wins.",
+				Optional:    true,
 				Type:        schema.TypeInt,
+			},
+			"path": {
+				Description: "the fully-qualified path to the secret including its folder path and secret name, " +
+					"eg: '/my/folder/structure/secretName'. Either path or id must be set, and if both are set, " +
+					"id wins.",
+				Optional:    true,
+				Type:        schema.TypeString,
 			},
 		},
 	}

--- a/example.tf
+++ b/example.tf
@@ -21,6 +21,10 @@ variable "tss_server_url" {
 }
 
 variable "tss_secret_id" {
+  type = number
+}
+
+variable "tss_secret_path" {
   type = string
 }
 
@@ -36,7 +40,7 @@ data "tss_secret" "my_username" {
 }
 
 data "tss_secret" "my_password" {
-  id    = var.tss_secret_id
+  path  = var.tss_secret_path
   field = "password"
 }
 


### PR DESCRIPTION
This addresses issue #11 in that a secret may be addressed either by its numeric ID or by its folder path and secret name.

This pull request depends on [thycotic/tss-sdk-go#11](https://github.com/thycotic/tss-sdk-go/pull/11). 