### PR TITLE
Implement CRUD by adding the Secret and Generated Password resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 
 # IDE
 .vscode
+.idea
 
 # terraform
 .terraform/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Thycotic Secret Server - Terraform Provider
 
-The [Thycotic](https://thycotic.com/) [Secret Server](https://thycotic.com/products/secret-server/) [Terraform](https://www.terraform.io/) Provider allows you to access and reference Secrets in your vault for use in Terraform configurations.
+The [Thycotic](https://thycotic.com/) [Secret Server](https://thycotic.com/products/secret-server/) [Terraform](https://www.terraform.io/) 
+Provider allows you to access and reference Secrets in your vault for use in Terraform configurations. It also allows 
+you to create new Secrets, generate passwords for those secrets that are compliant with the secret's password policy, 
+and use the generated passwords in the Terraform configuration. 
 
 ## Install via Registry
 
@@ -71,3 +74,104 @@ tss_password   = "Passw0rd."
 tss_server_url = "https://example/SecretServer"
 tss_secret_id  = "1"
 ```
+
+## Secret Data Source
+
+The Secret Data Source provides a read-only reference to one of the fields on 
+an _existing_ secret in the Thycotic server. The following is an example of 
+how to declare a Secret Data Source in your configuration:
+
+```terraform
+data "tss_secret" "my_password" {
+  id    = var.tss_secret_id
+  field = "password"
+}
+```
+
+Below are the attributes for the Secret Data Source:
+
+| Attribute Name | Attribute Type     | Usage    | Description                                                                                                                                                                                    |
+|----------------|--------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id             | Integer            | Required | The numerical identifier of the secret to reference.                                                                                                                                           |
+| field          | String             | Required | The name of the secret field to reference. The field name is also known as the field 'slug' in the Thycotic API.                                                                              |
+| value          | String (Sensitive) | Computed | The value of the named field. **WARNING**: Although this is a sensitive field and is masked in the Terraform CLI output, know that this value is available in plaintext in the Terraform state file. |
+
+## Secret Resource
+
+The Secret Resource is a Secret in the Terraform server that is fully managed by 
+the Terraform configuration. The following is an example of how to declare a 
+Secret Resource in your configuration:
+
+```terraform
+resource "tss_secret" "new_secret" {
+  name = "Secret Managed by Terraform"
+  secret_template_id = 6040
+  folder_id = 6
+  item {
+    field = "password"
+    value = "Shhhhhhhhhhhhhh!-123"
+  }
+  item {
+    field = "certificate"
+    value = file("/path/my-certificate.cer")
+    filename = "my-certificate.cer"
+  }
+  item {
+    field = "key-pair"
+    value = filebase64("/path/my-keys.pfx")
+    filename = "my-keys.pfx"
+    file_encoded = true
+  }
+}
+```
+
+Below are the attributes you'll most likely use for the Secret Resource. Other 
+attributes are described in the schema at the bottom of `resource_secret.go`:
+
+| Attribute Name     | Attribute Type | Usage    | Description                                                                                                                                                                                                                                             |
+|--------------------|----------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name               | String         | Required | A display name for the secret in the Thycotic web interface.                                                                                                                                                                                            |
+| secret_template_id | Integer        | Required | The numerical ID of the template that defines what fields are available on the secret.                                                                                                                                                                                 |
+| folder_id          | Integer        | Optional | The numerical ID of the folder that contains the secret. If a folder ID is not provided, the secret will be kept in the root folder. The user in the provider configuration must have permissions to write to this folder for the operation to succeed. |
+| item               | Block          | Required | One or more items that populate the fields defined in the secret's template. The item structure is described in the following table.                                                                                                                    |
+
+Below are the attributes on each `item` block that you're most likely to use for
+the Secret Resource. Other attributes are described in the schema at the bottom 
+of `resource_secret.go`:
+
+| Attribute Name | Attribute Type     | Usage    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|----------------|--------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| field          | String             | Required | The name of the secret field that corresponds to this item. The field name is also known as the field 'slug' in the Thycotic API. The template for the secret defines what field names are available for the secret, as well as the type for each field (eg: text, note, password, file, list, etc.)                                                                                                                                                          |
+| value          | String (Sensitive) | Required | The value for the field. If this item is a file item, you may provide the contents of the file here directly as plain text, or you may use one of the Terraform functions to read in the contents of a file on disk, such as `file("/some/file/path.txt")` or `filebase64("/some/file/path.txt")`. **WARNING**: Although this is a sensitive field and is masked in the Terraform CLI output, know that this value is available in plaintext in the Terraform state file.                                                                                                                                                           |
+| filename       | String             | Optional | The name to give a file when it is uploaded to the Thycotic server. Default value is `File.txt` if a name is not provided. This attribute is ignored if the field is not a file field.                                                                                                                                                                                                                                                                        |
+| file_encoded   | Boolean            | Optional | Whether the contents of the file attachment have been Base64 encoded and should therefore be decoded by this plugin before posting the file contents to the Thycotic Secret Server. You should set this to `true` if you're using the Terraform `filebase64()` function to read in the contents of a file that is _not_ UTF-8 encoded, which is a requirement for the Terraform `file()` function. This attribute is ignored if this item is not a file item. |
+
+## Generated Password Resource
+
+The Generated Password Resource is provided as a means to generate a password
+that conforms a secret's password policy. The output of this resource may then
+be used to populate the sensitive fields on a Secret Resource. The following 
+is an example of how to declare a Generated Password Resource in your 
+configuration:
+
+```terraform
+resource "tss_generated_password" "database_user_password" {
+  template_id = 6040
+  field = "password"
+}
+```
+
+Below are the attributes for the Generated Password Resource:
+
+| Attribute Name | Attribute Type     | Usage    | Description                                                                                                                                                                                        |
+|----------------|--------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| template_id    | Integer            | Required | The numerical identifier of the secret template which contains the password field, and which declares minimum password requirements for that field.                                                |
+| field          | String             | Required | The name (aka: slug) of the field for which the password is generated. This field must be declared on the secret template as a password field.                                                     |
+| value          | String (Sensitive) | Computed | The generated password. **WARNING**: Although this is a sensitive field and is masked in the Terraform CLI output, know that this value is available in plaintext in the Terraform state file. |
+
+**NOTE**: The Generated Password should ideally have been modelled as a Terraform 
+data source since it simply provides data. However, because the password is 
+ephemeral and does not persist anywhere on the Thycotic server, this plugin has no
+way to know if a read on its value is the first read, second read, and so on. This
+would force such a data source to generate a new value with each execution of the 
+Terraform plan, which is counterproductive.

--- a/example.tf
+++ b/example.tf
@@ -40,6 +40,32 @@ data "tss_secret" "my_password" {
   field = "password"
 }
 
+resource "tss_secret" "new_secret" {
+  name = "Secret Managed by Terraform"
+  secret_template_id = 6040
+  folder_id = 6
+  item {
+    field = "password"
+    value = tss_generated_password.generated_password_for_new_secret.value
+  }
+  item {
+    field = "certificate"
+    value = file("/path/my-certificate.cer")
+    filename = "my-certificate.cer"
+  }
+  item {
+    field = "key-pair"
+    value = filebase64("/path/my-keys.pfx")
+    filename = "my-keys.pfx"
+    file_encoded = true
+  }
+}
+
+resource "tss_generated_password" "generated_password_for_new_secret" {
+  template_id = 6040
+  field = "password"
+}
+
 output "username" {
   value     = data.tss_secret.my_username.value
 }

--- a/provider.go
+++ b/provider.go
@@ -18,6 +18,10 @@ func providerConfig(d *schema.ResourceData) (interface{}, error) {
 // Provider is a Terraform DataSource
 func Provider() *schema.Provider {
 	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"tss_generated_password": resourceGeneratedPassword(),
+			"tss_secret":             resourceSecret(),
+		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"tss_secret": dataSourceSecret(),
 		},

--- a/resource_generated_password.go
+++ b/resource_generated_password.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/lang/funcs"
+	"github.com/thycotic/tss-sdk-go/server"
+	"log"
+)
+
+func resourceGeneratedPasswordCreate(d *schema.ResourceData, meta interface{}) error {
+
+	templateId := d.Get("template_id").(int)
+	field := d.Get("field").(string)
+
+	log.Printf("[DEBUG] generating password for the '%s' field on template with id '%d'", field, templateId)
+
+	tss, err := server.New(meta.(server.Configuration))
+	if err != nil {
+		log.Printf("[ERROR] configuration error: %s", err)
+		return err
+	}
+
+	template, err := tss.SecretTemplate(templateId)
+	if err != nil {
+		log.Printf("[ERROR] unable to retrieve the template with ID '%d': %s", templateId, err)
+		return err
+	}
+
+	generatedPassword, err := tss.GeneratePassword(field, template)
+	if err != nil {
+		log.Printf("[ERROR] unable to generate a password for the '%s' field on the template with ID '%d': %s",
+			field, templateId, err)
+		return err
+	}
+
+	if err := d.Set("value", generatedPassword); err != nil {
+		log.Printf("[ERROR] unable to save the password value to state for the '%s' field on the template " +
+			"with ID '%d': %s", field, templateId, err)
+		return err
+	}
+	val, _ := funcs.UUID()
+	d.SetId(val.AsString())
+
+	return nil
+}
+
+// resourceGeneratedPasswordOther is a no-op method for all the CRUD methods except 'create'. Since passwords generated
+// by the Thycotic SDK are ephemeral, we don't want to re-read or update the password, and we don't need to delete it.
+//
+// This resource probably would have been better modelled as a data source, but a data source has only a read
+// method, and since a data source has no recorded state (outside its configuration), each read would produce a new
+// value. This would eliminate a generated password's utility as a persistent datum.
+func resourceGeneratedPasswordOther(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceGeneratedPassword() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGeneratedPasswordCreate,
+		Read:   resourceGeneratedPasswordOther,
+		Update: resourceGeneratedPasswordOther,
+		Delete: resourceGeneratedPasswordOther,
+
+		Schema: map[string]*schema.Schema{
+			"value": {
+				Computed:    true,
+				Description: "the value of the generated password",
+				Sensitive:   true,
+				Type:        schema.TypeString,
+			},
+			"field": {
+				Description: "the name (aka: slug) of the field for which the password is generated. This field must " +
+					"be declared on the secret template as a password field",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			"template_id": {
+				Description: "the id of the secret template which contains the password field, and which declares " +
+					"minimum password requirements for that field",
+				Required:    true,
+				Type:        schema.TypeInt,
+			},
+		},
+	}
+}

--- a/resource_secret.go
+++ b/resource_secret.go
@@ -1,0 +1,526 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/thycotic/tss-sdk-go/server"
+	"log"
+	"strconv"
+)
+
+func resourceSecretCreate(resourceSecret *schema.ResourceData, meta interface{}) error {
+	tss, err := server.New(meta.(server.Configuration))
+	if err != nil {
+		log.Printf("[ERROR] configuration error: %s", err)
+		return err
+	}
+	log.Printf("[DEBUG] creating secret with name '%s'", resourceSecret.Get("name"))
+
+	template, err := fetchTemplateForResourceSecret(resourceSecret, tss)
+	if err != nil {
+		log.Printf("[ERROR] unable to fetch template for the secret: %s", err)
+		return err
+	}
+
+	secretModel, err:= resourceSecretToModel(resourceSecret, template, 0)
+	if err != nil {
+		log.Printf("[ERROR] error converting secret resource to model: %s", err)
+		return err
+	}
+
+	secret, err := tss.CreateSecret(*secretModel)
+	if err != nil {
+		log.Printf("[ERROR] unable to create secret: %s", err)
+		return err
+	}
+
+	err = modelToResourceSecret(secret, resourceSecret)
+	if err != nil {
+		log.Printf("[ERROR] error converting model to secret resource: %s", err)
+		return err
+	}
+
+	log.Printf("[DEBUG] created secret with name '%s' and ID '%d'", secret.Name, secret.ID)
+	return nil
+}
+
+func resourceSecretRead(resourceSecret *schema.ResourceData, meta interface{}) error {
+	id, err := strconv.Atoi(resourceSecret.Id())
+	if err != nil {
+		log.Printf("[ERROR] configuration error, ID is not an integer: %s", resourceSecret.Id())
+		return err
+	}
+
+	tss, err := server.New(meta.(server.Configuration))
+	if err != nil {
+		log.Printf("[ERROR] configuration error: %s", err)
+		return err
+	}
+	log.Printf("[DEBUG] reading secret with name '%s' and ID '%d'", resourceSecret.Get("name"), id)
+
+	secret, err := tss.Secret(id)
+	if err != nil {
+		log.Printf("[ERROR] unable to read secret: %s", err)
+		return err
+	}
+
+	err = modelToResourceSecret(secret, resourceSecret)
+	if err != nil {
+		log.Printf("[ERROR] error converting model to resource secret: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func resourceSecretUpdate(resourceSecret *schema.ResourceData, meta interface{}) error {
+	id, err := strconv.Atoi(resourceSecret.Id())
+	if err != nil {
+		log.Printf("[ERROR] configuration error, ID is not an integer: %s", resourceSecret.Id())
+		return err
+	}
+
+	tss, err := server.New(meta.(server.Configuration))
+	if err != nil {
+		log.Printf("[ERROR] configuration error: %s", err)
+		return err
+	}
+	log.Printf("[DEBUG] updating secret with name '%s' and ID '%d'", resourceSecret.Get("name"), id)
+
+	template, err := fetchTemplateForResourceSecret(resourceSecret, tss)
+	if err != nil {
+		log.Printf("[ERROR] unable to fetch template for the secret: %s", err)
+		return err
+	}
+
+	secretModel, err:= resourceSecretToModel(resourceSecret, template, id)
+	if err != nil {
+		log.Printf("[ERROR] error converting resource secret to model: %s", err)
+		return err
+	}
+
+	secret, err := tss.UpdateSecret(*secretModel)
+	if err != nil {
+		log.Printf("[ERROR] unable to update secret: %s", err)
+		return err
+	}
+
+	err = modelToResourceSecret(secret, resourceSecret)
+	if err != nil {
+		log.Printf("[ERROR] error converting model to resource secret: %s", err)
+		return err
+	}
+
+	log.Printf("[DEBUG] updated secret with name '%s' and ID '%d'", secret.Name, secret.ID)
+	return nil
+}
+
+func resourceSecretDelete(resourceSecret *schema.ResourceData, meta interface{}) error {
+	id, err := strconv.Atoi(resourceSecret.Id())
+	if err != nil {
+		log.Printf("[ERROR] configuration error, ID is not an integer: %s", resourceSecret.Id())
+		return err
+	}
+
+	tss, err := server.New(meta.(server.Configuration))
+	if err != nil {
+		log.Printf("[ERROR] configuration error: %s", err)
+		return err
+	}
+	log.Printf("[DEBUG] deleting secret with name '%s' and ID '%d'", resourceSecret.Get("name"), id)
+
+	err = tss.DeleteSecret(id)
+	if err != nil {
+		log.Printf("[ERROR] unable to delete secret: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func fetchTemplateForResourceSecret(resourceSecret *schema.ResourceData, server *server.Server) (*server.SecretTemplate, error) {
+	secretTemplateId := resourceSecret.Get("secret_template_id").(int)
+	return server.SecretTemplate(secretTemplateId)
+}
+
+func resourceSecretToModel(resourceSecret *schema.ResourceData, template *server.SecretTemplate, id int) (*server.Secret, error) {
+	secret := new(server.Secret)
+	var err error
+
+	secret.ID = id
+	secret.Active = resourceSecret.Get("active").(bool)
+	secret.AutoChangeEnabled = resourceSecret.Get("auto_change_enabled").(bool)
+	secret.CheckOutChangePasswordEnabled = resourceSecret.Get("check_out_change_password_enabled").(bool)
+	secret.CheckOutEnabled = resourceSecret.Get("check_out_enabled").(bool)
+	secret.CheckOutIntervalMinutes = resourceSecret.Get("check_out_interval_minutes").(int)
+	secret.DelayIndexing = resourceSecret.Get("delay_indexing").(bool)
+	secret.EnableInheritPermissions = resourceSecret.Get("enable_inherit_permissions").(bool)
+	secret.EnableInheritSecretPolicy = resourceSecret.Get("enable_inherit_secret_policy").(bool)
+	secret.FolderID = resourceSecret.Get("folder_id").(int)
+	secret.Name = resourceSecret.Get("name").(string)
+	secret.ProxyEnabled = resourceSecret.Get("proxy_enabled").(bool)
+	secret.RequiresComment = resourceSecret.Get("requires_comment").(bool)
+	secret.SecretPolicyID = resourceSecret.Get("secret_policy_id").(int)
+	secret.SecretTemplateID = resourceSecret.Get("secret_template_id").(int)
+	secret.SessionRecordingEnabled = resourceSecret.Get("session_recording_enabled").(bool)
+	secret.SiteID = resourceSecret.Get("site_id").(int)
+	secret.WebLauncherRequiresIncognitoMode = resourceSecret.Get("web_launcher_requires_incognito_mode").(bool)
+
+	// Iterate the configuration's item values and map them
+	// into the model's fields
+	resourceItems := resourceSecret.Get("item").([]interface{})
+	secret.Fields = []server.SecretField{}
+	initializedFields := make(map[string]string)
+	for _, resourceItem := range resourceItems {
+		resourceItemMap := resourceItem.(map[string]interface{})
+		secretField := server.SecretField{}
+
+		// Transfer the field name (aka 'slug'), and use it to set the field ID
+		// which is required by the TSS API to bind an item to a field on the
+		// secret
+		var templateField *server.SecretTemplateField
+		if resourceField, found := resourceItemMap["field"]; found {
+			secretField.Slug = resourceField.(string)
+			if templateField, found = template.GetField(secretField.Slug); found {
+				secretField.FieldID = templateField.SecretTemplateFieldID
+			} else {
+				return nil, fmt.Errorf("[ERROR] an item on the secret named '%s' has an unrecognized field name '%s'",
+					secret.Name, secretField.Slug)
+			}
+		} else {
+			return nil, fmt.Errorf("[ERROR] an item on the secret named '%s' is missing a field name", secret.Name)
+		}
+
+		// Transfer the item value
+		if resourceValue, found := resourceItemMap["value"]; found {
+			if resourceFileEncoded, encodedFound := resourceItemMap["file_encoded"];
+					templateField.IsFile && encodedFound && resourceFileEncoded.(bool) {
+				log.Printf("[DEBUG] Decoding file from base64 before posting to Thycotic server")
+				valueDecoded, err := base64.StdEncoding.DecodeString(resourceValue.(string))
+				if err != nil {
+					return nil, err
+				}
+				secretField.ItemValue = string(valueDecoded)
+			} else {
+				secretField.ItemValue = resourceValue.(string)
+			}
+		} else {
+			return nil, fmt.Errorf("[ERROR] an item on the secret named '%s' is missing a value. To remove " +
+				"an optional field from a secret, simply remove the item from the secret's item list in the " +
+				"configuration", secret.Name)
+		}
+
+		// Transfer the filename, if present
+		if resourceFilename, found := resourceItemMap["filename"]; found {
+			secretField.Filename = resourceFilename.(string)
+		} else {
+			secretField.Filename = "File.txt"
+		}
+
+		secret.Fields = append(secret.Fields, secretField)
+		initializedFields[secretField.Slug] = secretField.Slug
+	}
+
+	// Iterate the template's fields, and if any of them have not been initialized
+	// above, set their value to an empty string. This approach allows the terraform 
+	// user to remove an item from a secret by simply removing its entry from the 
+	// "item" list in the configuration's secret declaration.
+	for _, templateField := range template.Fields {
+		if _, found := initializedFields[templateField.FieldSlugName]; !found {
+			secretField := server.SecretField{}
+			secretField.Slug = templateField.FieldSlugName
+			secretField.FieldID = templateField.SecretTemplateFieldID
+			secretField.ItemValue = ""
+			secret.Fields = append(secret.Fields, secretField)
+		}
+	}
+
+	return secret, err
+}
+
+func modelToResourceSecret(model *server.Secret, resourceSecret *schema.ResourceData) error {
+	resourceSecret.SetId(strconv.Itoa(model.ID))
+
+	var err error
+	if err = resourceSecret.Set("active", model.Active); err != nil { return err }
+	if err = resourceSecret.Set("auto_change_enabled", model.AutoChangeEnabled); err != nil { return err }
+	if err = resourceSecret.Set("check_out_change_password_enabled", model.CheckOutChangePasswordEnabled); err != nil { return err }
+	if err = resourceSecret.Set("check_out_enabled", model.CheckOutEnabled); err != nil { return err }
+	if err = resourceSecret.Set("check_out_interval_minutes", model.CheckOutIntervalMinutes); err != nil { return err }
+	if err = resourceSecret.Set("delay_indexing", model.DelayIndexing); err != nil { return err }
+	if err = resourceSecret.Set("enable_inherit_permissions", model.EnableInheritPermissions); err != nil { return err }
+	if err = resourceSecret.Set("enable_inherit_secret_policy", model.EnableInheritSecretPolicy); err != nil { return err }
+	if err = resourceSecret.Set("folder_id", model.FolderID); err != nil { return err }
+	if err = resourceSecret.Set("name", model.Name); err != nil { return err }
+	if err = resourceSecret.Set("proxy_enabled", model.ProxyEnabled); err != nil { return err }
+	if err = resourceSecret.Set("requires_comment", model.RequiresComment); err != nil { return err }
+	if err = resourceSecret.Set("secret_policy_id", model.SecretPolicyID); err != nil { return err }
+	if err = resourceSecret.Set("secret_template_id", model.SecretTemplateID); err != nil { return err }
+	if err = resourceSecret.Set("session_recording_enabled", model.SessionRecordingEnabled); err != nil { return err }
+	if err = resourceSecret.Set("site_id", model.SiteID); err != nil { return err }
+	if err = resourceSecret.Set("web_launcher_requires_incognito_mode", model.WebLauncherRequiresIncognitoMode); err != nil { return err }
+
+	resourceItems := resourceSecret.Get("item").([]interface{})
+	if model.Fields == nil {
+		resourceItems = make([]interface{}, 0)
+	} else {
+		mappedFields := make(map[string]string)
+
+		// First iterate items in the configuration and map in values from the model.
+		// Mapping in this way preserves the order in the configuration, making state
+		// comparisons more predictable.
+		for _, item := range resourceItems {
+			resourceItem := item.(map[string]interface{})
+			var field server.SecretField
+			for _, field = range model.Fields {
+				if field.Slug == resourceItem["field"] { mappedFields[field.Slug] = field.Slug; break }
+			}
+			if &field == nil {
+				return fmt.Errorf("[ERROR] an item on the secret named '%s' has an unrecognized field name '%s'", model.Name, resourceItem["field"])
+			}
+			mapModelFieldToResourceSecretItem(&field, resourceItem)
+			// If the configuration indicates that the value is encoded, re-encode
+			// the value for state maintenance
+			if resourceEncoded, found := resourceItem["file_encoded"]; field.IsFile && found && resourceEncoded.(bool) {
+				log.Printf("[DEBUG] Encoding file to base64 before returning to Terraform state")
+				resourceItem["value"] = base64.StdEncoding.EncodeToString([]byte(resourceItem["value"].(string)))
+			}
+		}
+
+		// Now iterate fields in the model. For every field that has a value and has
+		// not already been mapped, add it to the resource items to pick up changes
+		// made outside the configuration.
+		for _, field := range model.Fields {
+			slug := field.Slug
+			if _, found := mappedFields[slug]; !found {
+				hasValue := false
+				if field.IsFile {
+					hasValue = field.Filename != ""
+				} else {
+					hasValue = field.ItemValue != ""
+				}
+				if hasValue {
+					resourceItem := make(map[string]interface{})
+					mapModelFieldToResourceSecretItem(&field, resourceItem)
+					resourceItems = append(resourceItems, resourceItem)
+				}
+			}
+		}
+	}
+	if err = resourceSecret.Set("item", resourceItems); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func mapModelFieldToResourceSecretItem(field *server.SecretField, resourceItem map[string]interface{}) {
+	resourceItem["field"] = field.Slug
+	resourceItem["value"] = field.ItemValue
+	resourceItem["filename"] = field.Filename
+	resourceItem["field_description"] = field.FieldDescription
+	resourceItem["field_id"] = field.FieldID
+	resourceItem["field_name"] = field.FieldName
+	resourceItem["file_attachment_id"] = field.FileAttachmentID
+	resourceItem["is_file"] = field.IsFile
+	resourceItem["is_notes"] = field.IsNotes
+	resourceItem["is_password"] = field.IsPassword
+	resourceItem["item_id"] = field.ItemID
+}
+
+func resourceSecret() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSecretCreate,
+		Read:   resourceSecretRead,
+		Update: resourceSecretUpdate,
+		Delete: resourceSecretDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "the display name of the secret",
+				Required:    true,
+			},
+			"secret_template_id": {
+				Type:        schema.TypeInt,
+				Description: "the id of the template that defines the fields for secret",
+				Required:    true,
+			},
+			"site_id": {
+				Type:        schema.TypeInt,
+				Description: "the id of the distributed engine site that is used by this secret for operations such " +
+					"as password changing",
+				Optional:    true,
+				Default:     1,
+			},
+			"folder_id": {
+				Type:        schema.TypeInt,
+				Description: "the id of the folder which contains the secret. Set to nil, to -1, or leave unset for " +
+					"secrets in the root folder",
+				Optional:    true,
+			},
+			"secret_policy_id": {
+				Type:        schema.TypeInt,
+				Description: "the id of the secret policy that controls the security and other settings of the secret",
+				Optional:    true,
+				Default:     -1,
+			},
+			"item": {
+				Type:        schema.TypeList,
+				Description: "array of values for the fields defined in the secret template",
+				Required:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field": {
+							Type:        schema.TypeString,
+							Description: "unique name for the field on the secret template, also known in the " +
+								"Thycotic API as a 'slug'. Field names/slugs are used in many places to easily refer " +
+								"to a field without having to know the field id",
+							Required:    true,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Description: "the value for the field. If this item is a file item, you may provide " +
+								"the contents of the file here directly as plain text, or you may use one of the " +
+								"Terraform functions to read in the contents of a file on disk, such as " +
+								"'file(\"/some/file/path.txt\")' or 'filebase64(\"/some/file/path.txt\")'",
+							Required:    true,
+							Sensitive:   true,
+						},
+						"filename": {
+							Type:        schema.TypeString,
+							Description: "the name of the file attachment. This should be provided if this item is " +
+								"a file item and is ignored otherwise. Default is 'File.txt' if a name is not " +
+								"provided here. Keep in mind that the Thycotic Secret Server has a configurable " +
+								"list of acceptable filename extensions, and this filename must comply with that list",
+							Optional:    true,
+						},
+						"file_encoded": {
+							Type:        schema.TypeBool,
+							Description: "whether the contents of the file attachment have been Base64 encoded and " +
+								"should therefore be decoded by this plugin before posting the file contents to the " +
+								"Thycotic Secret Server. You should set this to 'true' if you're using the Terraform " +
+								"'filebase64()' function to read in the contents of a file that is _not_ UTF-8 " +
+								"encoded, which is a requirement for the Terraform 'file()' function. This value is " +
+								"ignored if this item is not a file item",
+							Optional:    true,
+							Default:     false,
+						},
+						"field_description": {
+							Type:        schema.TypeString,
+							Description: "longer description of the secret field",
+							Computed:    true,
+						},
+						"field_id": {
+							Type:        schema.TypeInt,
+							Description: "the id of the field definition from the secret template",
+							Computed:    true,
+						},
+						"field_name": {
+							Type:        schema.TypeString,
+							Description: "the display name of the secret field",
+							Computed:    true,
+						},
+						"file_attachment_id": {
+							Type:        schema.TypeInt,
+							Description: "ID of the file attachment",
+							Computed:    true,
+						},
+						"is_file": {
+							Type:        schema.TypeBool,
+							Description: "whether the field is a file attachment",
+							Computed:    true,
+						},
+						"is_notes": {
+							Type:        schema.TypeBool,
+							Description: "whether the field is represented as a multi-line text box used for " +
+								"long-form text fields",
+							Computed:    true,
+						},
+						"is_password": {
+							Type:        schema.TypeBool,
+							Description: "whether the field is a password attachment",
+							Computed:    true,
+						},
+						"item_id": {
+							Type:        schema.TypeInt,
+							Description: "the id of the secret field item",
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"active": {
+				Type:        schema.TypeBool,
+				Description: "whether the secret is in an active or deleted state",
+				Computed:    true,
+			},
+			"auto_change_enabled": {
+				Type:        schema.TypeBool,
+				Description: "whether the secret’s password is automatically rotated on a schedule, default is false",
+				Optional:    true,
+			},
+			"check_out_change_password_enabled": {
+				Type:        schema.TypeBool,
+				Description: "whether the secret’s password is automatically changed when a secret is checked in, " +
+					"default is false. This is a security feature that prevents use of the password " +
+					"retrieved from check-out after the secret is checked in",
+				Optional:    true,
+			},
+			"check_out_enabled": {
+				Type:        schema.TypeBool,
+				Description: "whether the user must check-out the secret to view it, default is false. Checking out " +
+					"gives the user exclusive access to the secret for a specified period or until the " +
+					"secret is checked in.",
+				Optional:    true,
+			},
+			"check_out_interval_minutes": {
+				Type:        schema.TypeInt,
+				Description: "the number of minutes that a secret will remain checked out",
+				Optional:    true,
+				Default:     -1,
+			},
+			"delay_indexing": {
+				Type:        schema.TypeBool,
+				Description: "whether the search indexing should be delayed to the background process, default is " +
+					"false. This can speed up bulk secret creation scripts by offloading the task of " +
+					"indexing the new secrets to the background task at the trade-off of not having search " +
+					"indexes immediately available",
+				Optional:    true,
+			},
+			"enable_inherit_permissions": {
+				Type:        schema.TypeBool,
+				Description: "whether the secret inherits permissions from the containing folder, default is true",
+				Optional:    true,
+				Default:     true,
+			},
+			"enable_inherit_secret_policy": {
+				Type:        schema.TypeBool,
+				Description: "whether the secret policy is inherited from the containing folder, default is false",
+				Optional:    true,
+			},
+			"proxy_enabled": {
+				Type:        schema.TypeBool,
+				Description: "whether sessions launched on this secret use Secret Server’s proxying or connect " +
+					"directly, default is false",
+				Optional:    true,
+			},
+			"requires_comment": {
+				Type:        schema.TypeBool,
+				Description: "whether the user must enter a comment to view the secret, default is false",
+				Optional:    true,
+			},
+			"session_recording_enabled": {
+				Type:        schema.TypeBool,
+				Description: "whether session recording is enabled, default is false",
+				Optional:    true,
+			},
+			"web_launcher_requires_incognito_mode": {
+				Type:        schema.TypeBool,
+				Description: "whether the web launcher will require the browser to run in incognito mode, default is " +
+					"false",
+				Optional:    true,
+			},
+		},
+	}
+}


### PR DESCRIPTION
This addresses #26. All secret field types (eg: note, text, password, file) are supported with the exception of the 'list' field type. 

This PR depends on [PR 12](https://github.com/thycotic/tss-sdk-go/pull/12) from [tss-sdk-go](https://github.com/thycotic/tss-sdk-go)