### PR TITLE
feat: add support for env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,17 @@ tss_password   = "Passw0rd."
 tss_server_url = "https://example/SecretServer"
 tss_secret_id  = "1"
 ```
+## Environment variables
+
+You can provide your credentials via the TSS_SERVER_URL, TSS_USERNAME and TSS_PASSWORD environment variables.
+In this case, tss provider could be represented like this 
+```
+provider "tss" {}
+```
+Usage
+```
+$ export TSS_USERNAME="my_app_user"
+$ export TSS_PASSWORD="Passw0rd."
+$ export TSS_SERVER_URL="https://localhost/SecretServer"
+$ terraform plan
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,21 @@ tss_server_url = "https://localhost/SecretServer"
 tss_secret_id  = "1"
 ```
 
+# Environment variables
+
+You can provide your credentials via the TSS_SERVER, TSS_USERNAME and TSS_PASSWORD environment variables.
+In this case, tss provider could be represented like this 
+```
+provider "tss" {}
+```
+Usage
+```
+$ export TSS_USERNAME="my_app_user"
+$ export TSS_PASSWORD="Passw0rd."
+$ export TSS_SERVER="https://localhost/SecretServer"
+$ terraform plan
+```
+
 ### Required
 
 - **password** (String) The password of the Secret Server User

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ tss_secret_id  = "1"
 
 # Environment variables
 
-You can provide your credentials via the TSS_SERVER, TSS_USERNAME and TSS_PASSWORD environment variables.
+You can provide your credentials via the TSS_SERVER_URL, TSS_USERNAME and TSS_PASSWORD environment variables.
 In this case, tss provider could be represented like this 
 ```
 provider "tss" {}
@@ -45,7 +45,7 @@ Usage
 ```
 $ export TSS_USERNAME="my_app_user"
 $ export TSS_PASSWORD="Passw0rd."
-$ export TSS_SERVER="https://localhost/SecretServer"
+$ export TSS_SERVER_URL="https://localhost/SecretServer"
 $ terraform plan
 ```
 

--- a/provider.go
+++ b/provider.go
@@ -25,16 +25,19 @@ func Provider() *schema.Provider {
 			"server_url": {
 				Type:        schema.TypeString,
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TSS_SERVER", nil),
 				Description: "The Secret Server base URL e.g. https://localhost/SecretServer",
 			},
 			"username": {
 				Type:        schema.TypeString,
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TSS_USERNAME", nil),
 				Description: "The username of the Secret Server User to connect as",
 			},
 			"password": {
 				Type:        schema.TypeString,
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TSS_PASSWORD", nil),
 				Description: "The password of the Secret Server User",
 			},
 		},

--- a/provider.go
+++ b/provider.go
@@ -25,7 +25,7 @@ func Provider() *schema.Provider {
 			"server_url": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TSS_SERVER", nil),
+				DefaultFunc: schema.EnvDefaultFunc("TSS_SERVER_URL", nil),
 				Description: "The Secret Server base URL e.g. https://localhost/SecretServer",
 			},
 			"username": {


### PR DESCRIPTION
Hi There
A simple contribution to add support to env variable. tss provider could be configured like this, when environment variable are set up.
```
provider "tss" {}
```

This is actually most of provider do, what do you thinks about ?